### PR TITLE
readme update in 01_nginx

### DIFF
--- a/01_nginx/README.md
+++ b/01_nginx/README.md
@@ -186,6 +186,10 @@ You can finally run it:
 
     launchctl load ~/Library/LaunchAgents/homebrew.mxcl.nginx.plist
 
+If you get the error `No such file or directory` when trying to run the launch agent, try:
+
+    brew services start nginx
+
 A `ps aux | grep nginx` should show a recently-started nginx master and worker
 process. If it isn't recent, you may need to unload and then load the plist
 again. If it doesn't show anything at all, take a look at


### PR DESCRIPTION
Hey, 
I don't know if homebrew changed things or what, but when I went through I noticed that on install they suggest starting the service with `brew services start nginx`